### PR TITLE
Update bridge for new Robocode API

### DIFF
--- a/bot_logic.py
+++ b/bot_logic.py
@@ -1,1 +1,29 @@
-print("Python bot started")
+import json
+import sys
+
+# Simple Python control logic for the bridge bot.
+# Receives line-delimited JSON events from Java over stdin and sends
+# simple commands back over stdout.
+
+def handle_event(evt):
+    if evt.get('event') == 'connected':
+        # Move forward a bit when connected
+        send_cmd('forward 150')
+    elif evt.get('event') == 'tick':
+        pass  # placeholder for more logic
+
+
+def send_cmd(cmd):
+    print(cmd, flush=True)
+
+if __name__ == '__main__':
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+            handle_event(event)
+        except json.JSONDecodeError:
+            # Ignore malformed lines
+            continue


### PR DESCRIPTION
## Summary
- extend `PythonBridgeBot` event handling to cover new Robocode API events
- accept simple commands like `forward 150` from `bot_logic.py`
- send updated JSON event structures
- implement minimal Python bot to parse events and send commands

## Testing
- `python -m py_compile bot_logic.py`


------
https://chatgpt.com/codex/tasks/task_e_6866f1ad4c5c832b823021d1193bad6b