### PR TITLE
Add run scripts for compiling without a jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 Python Java Relay for Robocode Tank Royale
+
+## Running without a JAR
+
+Use `run.sh` (or `run.bat` on Windows) to compile the Java sources and start the launcher directly.
+The script expects the Robocode Tank Royale API jars to be placed in a `lib` folder beside the sources.
+
+```
+./run.sh
+```

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,10 @@
+@echo off
+setlocal
+if not exist build mkdir build
+javac -d build -cp "lib/*" PythonBridgeBot.java Launcher.java
+if errorlevel 1 (
+    echo Compilation failed.
+    exit /b 1
+)
+java -cp "lib/*;build" Launcher %*
+endlocal

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Compile all Java sources and run the launcher.
+# Requires the Robocode Tank Royale jars under ./lib
+
+set -e
+mkdir -p build
+javac -d build -cp "lib/*" PythonBridgeBot.java Launcher.java
+java -cp "lib/*:build" Launcher "$@"


### PR DESCRIPTION
## Summary
- add `run.sh` shell script that compiles and runs the launcher
- add `run.bat` Windows script
- document the new scripts in `README.md`

## Testing
- `sh -n run.sh`

------
https://chatgpt.com/codex/tasks/task_e_686728fac154832b8a93ff9adf6cabb5