### PR TITLE
Add bot state exposure for Python control

### DIFF
--- a/PythonBridgeBot.java
+++ b/PythonBridgeBot.java
@@ -89,7 +89,7 @@ public class PythonBridgeBot extends Bot {
 
     @Override
     public void onTick(TickEvent e) {
-        sendToPy(EventJson.tick(e));
+        sendToPy(EventJson.tick(this, e));
     }
 
     @Override
@@ -303,8 +303,19 @@ public class PythonBridgeBot extends Bot {
         }
 
 
-        static String tick(TickEvent e) {
-            return "{\"event\":\"tick\",\"turn\":" + e.getTurnNumber() + "}";
+        static String tick(PythonBridgeBot bot, TickEvent e) {
+            return "{" +
+                    "\"event\":\"tick\"," +
+                    "\"turn\":" + e.getTurnNumber() + "," +
+                    "\"energy\":" + bot.getEnergy() + "," +
+                    "\"x\":" + bot.getX() + "," +
+                    "\"y\":" + bot.getY() + "," +
+                    "\"direction\":" + bot.getDirection() + "," +
+                    "\"gunDirection\":" + bot.getGunDirection() + "," +
+                    "\"radarDirection\":" + bot.getRadarDirection() + "," +
+                    "\"gunHeat\":" + bot.getGunHeat() + "," +
+                    "\"speed\":" + bot.getSpeed() +
+                    "}";
         }
 
         static String wonRound(WonRoundEvent e) {

--- a/bot_logic.py
+++ b/bot_logic.py
@@ -9,8 +9,14 @@ def handle_event(evt):
     if evt.get('event') == 'connected':
         # Move forward a bit when connected
         send_cmd('forward 150')
+        send_cmd('turnRadarRight 360')  # initial scan
     elif evt.get('event') == 'tick':
-        pass  # placeholder for more logic
+        # Access bot state sent from Java
+        energy = evt.get('energy')
+        gun_heat = evt.get('gunHeat')
+        # Example: fire when gun is cooled down
+        if gun_heat == 0:
+            send_cmd('fire 2.0')
 
 
 def send_cmd(cmd):


### PR DESCRIPTION
## Summary
- expose full bot state to Python by extending `tick` event
- demo usage in `bot_logic.py`

## Testing
- `python3 -m py_compile bot_logic.py`
- `./run.sh` *(fails: cannot find Robocode libraries)*

------
https://chatgpt.com/codex/tasks/task_e_68672db23464832b9309c2d46374b63c