### PR TITLE
Display python output

### DIFF
--- a/PythonBridgeBot.cmd
+++ b/PythonBridgeBot.cmd
@@ -1,2 +1,3 @@
 javac -cp lib/* PythonBridgeBot.java
-java -cp lib/*;. PythonBridgeBot >nul
+rem Run without redirecting output so the Python console is visible
+java -cp lib/*;. PythonBridgeBot

--- a/PythonBridgeBot.java
+++ b/PythonBridgeBot.java
@@ -147,6 +147,7 @@ public class PythonBridgeBot extends Bot {
         String line;
         try {
             while ((line = pyIn.readLine()) != null) {
+                System.out.println("[Python] " + line); // echo Python output to the console
                 handlePythonCommand(line.trim());
             }
         } catch (IOException ex) {


### PR DESCRIPTION
## Summary
- show Python output lines in console when Java runs Python
- keep console visible in Windows script

## Testing
- `./run.sh` *(fails: cannot find symbol botapi)*

------
https://chatgpt.com/codex/tasks/task_e_686810ec05a0832bb9d1b937befaed83