### PR TITLE
Refactor bot logic to use run event

### DIFF
--- a/bot_logic.py
+++ b/bot_logic.py
@@ -1,13 +1,13 @@
 import json
 import sys
-import threading
 
 """Basic Python logic for the bridge bot.
 
 This script mirrors the behaviour of the simple Java bot shown in the
-repository README.  It starts a background thread that continuously
-executes a movement pattern while the main thread listens for events
-from the Java side and reacts to scans and bullet hits.
+repository README. The Java side forwards events as JSON and this
+script reacts to them. Instead of running a separate background loop,
+we invoke :func:`run` once whenever an event is processed (or when no
+event is received).
 """
 
 # Current heading of our bot, updated on every tick
@@ -23,13 +23,12 @@ def normalize_angle(angle: float) -> float:
     return angle
 
 
-def main_loop():
-    """Continuously perform the movement pattern from MyFirstBot."""
-    while True:
-        send_cmd("forward 100")
-        send_cmd("turnGunLeft 360")
-        send_cmd("back 100")
-        send_cmd("turnGunLeft 360")
+def run():
+    """Execute one iteration of the movement pattern from MyFirstBot."""
+    send_cmd("forward 100")
+    send_cmd("turnGunLeft 360")
+    send_cmd("back 100")
+    send_cmd("turnGunLeft 360")
 
 
 def handle_event(evt):
@@ -38,8 +37,8 @@ def handle_event(evt):
     print(event)
 
     if event == "connected":
-        # Start movement in the background when the bot connects
-        threading.Thread(target=main_loop, daemon=True).start()
+        # Begin executing the movement pattern when the bot connects
+        run()
     elif event == "tick":
         # Track our current direction for bearing calculations
         bot_direction = evt.get("direction", bot_direction)
@@ -53,6 +52,10 @@ def handle_event(evt):
         turn_angle = 90 - bearing
         send_cmd(f"turnRight {turn_angle}")
 
+    # Execute one iteration of the bot's default movement each turn
+    if event != "run":
+        run()
+
 
 def send_cmd(cmd: str):
     print(cmd, flush=True)
@@ -62,10 +65,11 @@ if __name__ == "__main__":
     for line in sys.stdin:
         line = line.strip()
         if not line:
+            handle_event({"event": "run"})
             continue
         try:
             event = json.loads(line)
             handle_event(event)
         except json.JSONDecodeError:
-            # Ignore malformed lines
-            continue
+            # Use a synthetic run event when the input is not valid JSON
+            handle_event({"event": "run"})


### PR DESCRIPTION
## Summary
- remove background thread from `bot_logic.py`
- call `run()` whenever an event is handled or no event is received
- update documentation comments

## Testing
- `python -m py_compile bot_logic.py`

------
https://chatgpt.com/codex/tasks/task_e_68682595073c832b9d4c295657ce7392